### PR TITLE
Added data integrity checks to increase robustness against read errors

### DIFF
--- a/bin/easymeter.pl
+++ b/bin/easymeter.pl
@@ -189,7 +189,7 @@ $logger->info("start reading from device");
 my $rawData = readDevice();
 if ($rawData) {
 	# parse and transform raw data and create readable format
-	# $logger->debug("processing data: $rawData");
+	$logger->debug("processing data: $rawData");
 	my ($ownershipNumber, $importCounter, $exportCounter, $powerL1, $powerL2, $powerL3, $powerOverall, $state, $serialNumber) = parseRawData($rawData);
 
 	# process history data and calculate imported and exported power between this and the last run
@@ -822,7 +822,7 @@ sub processDataOpenHAB {
     # curl -s -X PUT -H "Content-Type: text/plain" -d "100" "http://openhab:8080/rest/items/easymeter_L1/state"
  		while ( my ($endpoint_url, $value) = each(%endpoint) ) {
 
- 		# $logger->debug("$endpoint_url -> $value");
+ 		$logger->debug("$endpoint_url -> $value");
 
 		# set custom HTTP request header fields
 		my $req = HTTP::Request->new(PUT => $endpoint_url);
@@ -836,7 +836,7 @@ sub processDataOpenHAB {
 		my $resp = $ua->request($req);
 		if ($resp->is_success) {
 	    	my $message = $resp->decoded_content;
-	    	# $logger->debug("Received reply: $message");
+	    	$logger->debug("Received reply: $message");
 		} else {
 	    	$logger->error("HTTP POST error code: $resp->code, ");
 	    	$logger->error("HTTP POST error message: $resp->message ");


### PR DESCRIPTION
I use the script a couple of years now, I noticed that somehow last year I got an increasing number of false values in my diagrams. I had no time to check closer, but maybe the reader hardware degraded. 
Anyhow, the last days I checked the output and noticed that there are no checks for invalid data if the telegram itself looks good. I changed the script to exit if such an error occurs (the script runs every minute, it doesn't matter if one measurement is missing). I also attached a log (search for 'error' to have a look at the erroneous values I receive sometimes). Since I made those changes, my graphs look fine again.
[easymeter.log](https://github.com/jschanz/easymeter/files/4299892/easymeter.log)
